### PR TITLE
Upgrade Node.js to latest LTS v14.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt-get install -y yarn && \
 # install nodejs
-    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs
-    
+
 # install Android tools
 ENV ANDROID_HOME=/opt/android-sdk-linux
 ENV PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This project contains a sample Dockerfile that declares an extended Upsource docker image with additional tools used for source code processing.
 
 It is inherited from [jetbrains/upsource](https://hub.docker.com/r/jetbrains/upsource/) and contains the following tools:
-- Node.js (latest LTS v12.x), 
+- Node.js (latest LTS v14.x), 
 - Yarn (latest stable)
 - PHP (latest stable)
 - Python 2.7.9 (part of the `openjdk:8` base image) 


### PR DESCRIPTION
The active Node.js LTS release is now v14: https://nodejs.org/en/about/releases/